### PR TITLE
StardewValley 1.6 is supported

### DIFF
--- a/BuyRecipes/BuyRecipes.csproj
+++ b/BuyRecipes/BuyRecipes.csproj
@@ -1,14 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <AssemblyName>Denifia.Stardew.BuyRecipes</AssemblyName>
     <RootNamespace>Denifia.Stardew.BuyRecipes</RootNamespace>
     <Version>2.1.0</Version>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
-
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DebugType>portable</DebugType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DebugType>portable</DebugType>
+  </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="3.0.0" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.1.1" />
   </ItemGroup>
-
 </Project>

--- a/BuyRecipes/Domain/CookingRecipe.cs
+++ b/BuyRecipes/Domain/CookingRecipe.cs
@@ -2,12 +2,16 @@
 using System.Collections.Generic;
 using System.Linq;
 using Denifia.Stardew.BuyRecipes.Framework;
+using StardewValley;
+using StardewValley.ItemTypeDefinitions;
 
 namespace Denifia.Stardew.BuyRecipes.Domain
 {
     public class CookingRecipe
     {
         public string Name { get; set; }
+
+        public string DisplayName { get; set; }
         public List<GameItemWithQuantity> Ingredients { get; set; }
         public GameItemWithQuantity ResultingItem { get; set; }
         public IRecipeAquisitionConditions AquisitionConditions { get; set; }
@@ -24,9 +28,17 @@ namespace Denifia.Stardew.BuyRecipes.Domain
 
             var unknownData = dataParts[1];
 
-            var resultingItemData = dataParts[2];
+            //string resultingItemData = dataParts[2];
+            string resultingItemData = ItemRegistry.QualifyItemId(dataParts[2]); ;
             ResultingItem = DeserializeResultingItem(resultingItemData);
-
+            if ( ResultingItem.DisplayName != null ) 
+            {
+                DisplayName = ResultingItem.DisplayName;
+            }
+            else
+            {
+                DisplayName = name;
+            }
             var aquisitionData = dataParts[3];
             var aquisitionConditions = BuyRecipes.RecipeAquisitionConditions.FirstOrDefault(x => x.AcceptsConditions(aquisitionData));
             if (aquisitionConditions == null)
@@ -74,14 +86,17 @@ namespace Denifia.Stardew.BuyRecipes.Domain
         {
             var itemWithQuantity = new GameItemWithQuantity
             {
-                Id = int.Parse(itemId),
+                Id = itemId,
                 Quantity = int.Parse(quantity),
             };
 
-            var gameItem = ModHelper.GameObjects.FirstOrDefault(x => x.Id == itemWithQuantity.Id);
+            // var gameItem = ModHelper.GameObjects.FirstOrDefault(x => x.Id == itemWithQuantity.Id);
+            ParsedItemData gameItem = ItemRegistry.GetData(itemId);
             if (gameItem != null)
             {
-                itemWithQuantity.Name = gameItem.Name;
+                //itemWithQuantity.Name = gameItem.Name;
+                itemWithQuantity.Name = gameItem.InternalName;
+                itemWithQuantity.DisplayName = gameItem.DisplayName;
             }
 
             return itemWithQuantity;

--- a/BuyRecipes/Domain/GameItem.cs
+++ b/BuyRecipes/Domain/GameItem.cs
@@ -3,6 +3,7 @@
     public class GameItem
     {
         public string Name { get; set; }
-        public int Id { get; set; }
+        public string DisplayName { get; set; }
+        public string Id { get; set; }
     }
 }

--- a/BuyRecipes/Framework/IGenericModConfigMenuApi.cs
+++ b/BuyRecipes/Framework/IGenericModConfigMenuApi.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using Denifia.Stardew.BuyRecipes.Framework;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using StardewModdingAPI;
+using StardewModdingAPI.Utilities;
+using StardewValley;
+
+namespace Denifia.Stardew.BuyRecipes.Framework
+{
+    /// <summary>The API which lets other mods add a config UI through Generic Mod Config Menu.</summary>
+    public interface IGenericModConfigMenuApi
+         // DELETE THIS LINE WHEN COPIED INTO YOUR MOD CODE
+    {
+        /*********
+        ** Methods
+        *********/
+        /****
+        ** Must be called first
+        ****/
+        /// <summary>Register a mod whose config can be edited through the UI.</summary>
+        /// <param name="mod">The mod's manifest.</param>
+        /// <param name="reset">Reset the mod's config to its default values.</param>
+        /// <param name="save">Save the mod's current config to the <c>config.json</c> file.</param>
+        /// <param name="titleScreenOnly">Whether the options can only be edited from the title screen.</param>
+        /// <remarks>Each mod can only be registered once, unless it's deleted via <see cref="Unregister"/> before calling this again.</remarks>
+        void Register(IManifest mod, Action reset, Action save, bool titleScreenOnly = false);
+
+        /// <summary>Add an integer option at the current position in the form.</summary>
+        /// <param name="mod">The mod's manifest.</param>
+        /// <param name="getValue">Get the current value from the mod config.</param>
+        /// <param name="setValue">Set a new value in the mod config.</param>
+        /// <param name="name">The label text to show in the form.</param>
+        /// <param name="tooltip">The tooltip text shown when the cursor hovers on the field, or <c>null</c> to disable the tooltip.</param>
+        /// <param name="min">The minimum allowed value, or <c>null</c> to allow any.</param>
+        /// <param name="max">The maximum allowed value, or <c>null</c> to allow any.</param>
+        /// <param name="interval">The interval of values that can be selected.</param>
+        /// <param name="formatValue">Get the display text to show for a value, or <c>null</c> to show the number as-is.</param>
+        /// <param name="fieldId">The unique field ID for use with <see cref="OnFieldChanged"/>, or <c>null</c> to auto-generate a randomized ID.</param>
+        void AddNumberOption(IManifest mod, Func<int> getValue, Action<int> setValue, Func<string> name, Func<string> tooltip = null, int? min = null, int? max = null, int? interval = null, Func<int, string> formatValue = null, string fieldId = null);
+
+
+        void OnFieldChanged(IManifest mod, Action<string, object> onChange);
+
+        /// <summary>Open the config UI for a specific mod.</summary>
+        /// <param name="mod">The mod's manifest.</param>
+ 
+
+        /// <summary>Remove a mod from the config UI and delete all its options and pages.</summary>
+        /// <param name="mod">The mod's manifest.</param>
+        void Unregister(IManifest mod);
+    }
+}

--- a/BuyRecipes/Framework/ModHelper.cs
+++ b/BuyRecipes/Framework/ModHelper.cs
@@ -6,35 +6,40 @@ namespace Denifia.Stardew.BuyRecipes.Framework
 {
     public static class ModHelper
     {
-        private static List<GameItem> _gameObjects;
-        public static List<GameItem> GameObjects
-        {
-            get
-            {
-                if (_gameObjects == null)
-                {
-                    DeserializeGameObjects();
-                }
-                return _gameObjects;
-            }
-        }
+        //private static List<GameItem> _gameObjects;
+        //public static List<GameItem> GameObjects
+        //{
+        //    get
+        //    {
+        //        if (_gameObjects == null)
+        //        {
+        //            DeserializeGameObjects();
+        //        }
+        //        return _gameObjects;
+        //    }
 
-        private static void DeserializeGameObjects()
-        {
-            _gameObjects = new List<GameItem>();
-            foreach (var item in Game1.objectInformation)
-            {
-                _gameObjects.Add(new GameItem
-                {
-                    Id = item.Key,
-                    Name = item.Value.Split('/')[4]
-                });
-            }
-        }
 
-        public static string GetMoneyAsString(int money)
-        {
-            return $"G{money.ToString("#,##0")}";
-        }
+ 
+
+        //private static void DeserializeGameObjects()
+        //{
+        //    _gameObjects = new List<GameItem>();
+        //    foreach (var item in Game1.objectData)
+        //    {    if ( item.Value.Type == "Cooking") 
+        //        {
+        //            _gameObjects.Add(new GameItem
+        //            {
+        //                Id = ItemRegistry.QualifyItemId(item.Key),
+        //                Name = item.Value.Name
+        //            });
+        //        }
+
+        //    }
+        //}
+
+        //public static string GetMoneyAsString(int money)
+        //{
+        //    return $"G{money.ToString("#,##0")}";
+        //}
     }
 }

--- a/BuyRecipes/ModConfig.cs
+++ b/BuyRecipes/ModConfig.cs
@@ -1,6 +1,12 @@
 ﻿namespace Denifia.Stardew.BuyRecipes
 {
-    public class ModConfig
+    public sealed class ModConfig
     {
+        public int maxNumberOfRecipesPerWeek { get; set; }
+
+        public ModConfig()
+        {
+            this.maxNumberOfRecipesPerWeek = 5;
+        }
     }
 }

--- a/BuyRecipes/i18n/default.json
+++ b/BuyRecipes/i18n/default.json
@@ -1,0 +1,4 @@
+{
+  "maxNumberOfRecipesPerWeek.name": "maxNumber",
+  "maxNumberOfRecipesPerWeek.description": "The maximum number of randomly generated recipes per week."
+}

--- a/BuyRecipes/i18n/zh.json
+++ b/BuyRecipes/i18n/zh.json
@@ -1,0 +1,4 @@
+{
+  "maxNumberOfRecipesPerWeek.name": "最大数量",
+  "maxNumberOfRecipesPerWeek.description": "每周随机显示可购买的食谱最大数量.（最低一个）"
+}


### PR DESCRIPTION
1. fix StardewValley 1.6
2. The configuration can be supported by GenericModConfigMenu
3. Improve loading speed by accessing smapi cached recipe data instead of using ModHelper
4. Console recipes support localization languages